### PR TITLE
Stemley 2024

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO" version "2024.3.1"
+    id "edu.wpi.first.GradleRIO" version "2024.3.2"
 }
 
 java {

--- a/simgui.json
+++ b/simgui.json
@@ -3,6 +3,9 @@
     "Addressable LEDs": {
       "0": {
         "columns": 30
+      },
+      "window": {
+        "visible": true
       }
     },
     "PWM Outputs": {

--- a/simgui.json
+++ b/simgui.json
@@ -1,15 +1,8 @@
 {
   "HALProvider": {
     "Addressable LEDs": {
-      "window": {
-        "visible": true
-      }
-    },
-    "Other Devices": {
-      "SPARK MAX [22]": {
-        "header": {
-          "open": true
-        }
+      "0": {
+        "columns": 30
       }
     },
     "PWM Outputs": {
@@ -30,11 +23,25 @@
     "Retained Values": {
       "open": false
     },
-    "Transitory Values": {
-      "open": false
+    "transitory": {
+      "Shuffleboard": {
+        ".recording": {
+          "open": true
+        },
+        "open": true
+      }
     }
   },
   "NetworkTables Info": {
+    "Connections": {
+      "open": true
+    },
+    "Server": {
+      "Publishers": {
+        "open": true
+      },
+      "open": true
+    },
     "visible": true
   }
 }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -1,7 +1,3 @@
-// Copyright (c) FIRST and other WPILib contributors.
-// Open Source Software; you can modify and/or share it under the terms of
-// the WPILib BSD license file in the root directory of this project.
-
 package frc.robot;
 
 import edu.wpi.first.wpilibj.RobotController;
@@ -22,65 +18,52 @@ import frc.robot.subsystems.ClimbSubsystem;
 import frc.robot.subsystems.DriveSubsystem;
 import frc.robot.subsystems.LightsSubsystem;
 
-/**
- * This class is where the bulk of the robot should be declared. Since
- * Command-based is a "declarative" paradigm, very little robot logic should
- * actually be handled in the {@link Robot} periodic methods (other than the
- * scheduler calls). Instead, the structure of the robot (including subsystems,
- * commands, and button mappings) should be declared here.
- */
 public class RobotContainer {
 
     // The operator input class
     private final OperatorInput                   operatorInput      = new OperatorInput();
 
-    // The robot's subsystems and commands are defined here...
-    private final LightsSubsystem                 lightsSubsystem    = new LightsSubsystem();
+    // The robot's subsystems and commands are defined here
+    private final LightsSubsystem                 lightsSubsystem    = new LightsSubsystem();            // LightsSubsystem
+                                                                                                         // initialized
     private final DriveSubsystem                  driveSubsystem     = new DriveSubsystem();
     private final ArmSubsystem                    armSubsystem       = new ArmSubsystem();
     private final ClimbSubsystem                  climbSubsystem     = new ClimbSubsystem(operatorInput);
 
-    // All dashboard choosers are defined here...
+    // All dashboard choosers are defined here
     private final SendableChooser<DriveMode>      driveModeChooser   = new SendableChooser<>();
     private final SendableChooser<AutoPattern>    autoPatternChooser = new SendableChooser<>();
     private final SendableChooser<RookieSettings> speedChooser       = new SendableChooser<>();
 
-    /**
-     * The container for the robot. Contains subsystems, OI devices, and commands.
-     */
     public RobotContainer() {
 
         // Initialize the dashboard choosers
         initDashboardChoosers();
 
-        // Initialize all Subsystem default commands.
+        // Set default commands for subsystems
         driveSubsystem.setDefaultCommand(
             new DefaultDriveCommand(operatorInput, speedChooser, driveModeChooser, driveSubsystem, lightsSubsystem));
 
         armSubsystem.setDefaultCommand(
             new DefaultArmCommand(operatorInput, armSubsystem));
 
-        // Initialize the default command of the subsystem, to keep the arm hovering over the
-        // ground.
-        // armSubsystem.setDefaultCommand(new DefaultKeepArmUpCommand(armSubsystem));
-
-        // Configure the button bindings
-        operatorInput.configureButtonBindings(driveSubsystem, armSubsystem, climbSubsystem);
+        // Configure the button bindings (ensure LightsSubsystem is passed)
+        operatorInput.configureButtonBindings(driveSubsystem, armSubsystem, climbSubsystem, lightsSubsystem);
 
         // Add a trigger to flash the lights when the robot goes from disabled to enabled
         new Trigger(() -> RobotController.isSysActive())
             .onTrue(new InstantCommand(() -> lightsSubsystem.setEnabled()));
-
-
     }
 
     private void initDashboardChoosers() {
 
+        // Drive Mode chooser
         driveModeChooser.setDefaultOption("Dual Stick Arcade", DriveMode.DUAL_STICK_ARCADE);
         SmartDashboard.putData("Drive Mode", driveModeChooser);
         driveModeChooser.addOption("Single Stick Arcade", DriveMode.SINGLE_STICK_ARCADE);
         driveModeChooser.addOption("Tank", DriveMode.TANK);
 
+        // Auto Pattern chooser
         autoPatternChooser.setDefaultOption("Do Nothing", AutoPattern.DO_NOTHING);
         SmartDashboard.putData("Auto Pattern", autoPatternChooser);
         autoPatternChooser.addOption("Test Arm Commands", AutoPattern.TEST_ARM_COMMANDS);
@@ -101,17 +84,10 @@ public class RobotContainer {
         autoPatternChooser.addOption("Blue Speaker side 1 shot", AutoPattern.BLUE_SPEAKER_ONE_SHOT);
         autoPatternChooser.addOption("Blue Speaker side 2 shot", AutoPattern.BLUE_SPEAKER_TWO_SHOT);
 
-        // autoPatternChooser.addOption("Red Outside side 2 shot",
-        // AutoPattern.RED_OUTSIDE_TWO_SHOT);
-        // autoPatternChooser.addOption("Red Speaker side 3 shot",
-        // AutoPattern.RED_SPEAKER_THREE_SHOT);
-        // autoPatternChooser.addOption("Blue Speaker side 3 shot",
-        // AutoPattern.BLUE_SPEAKER_THREE_SHOT);
-
-        speedChooser.setDefaultOption("Rookie driver", RookieSettings.ROOKIE);
+        // Speed chooser (Rookie vs Normal mode)
+        speedChooser.setDefaultOption("Normal driver", RookieSettings.NORMAL);
+        speedChooser.addOption("Rookie driver", RookieSettings.ROOKIE);
         SmartDashboard.putData("Rookie Mode", speedChooser);
-        speedChooser.addOption("Normal driver", RookieSettings.NORMAL);
-
     }
 
     /**
@@ -120,12 +96,13 @@ public class RobotContainer {
      * @return the command to run in autonomous
      */
     public Command getAutonomousCommand() {
-
-        // Pass in all of the subsystems and all of the choosers to the auto command.
+        // Pass subsystems, choosers, and LightsSubsystem to AutonomousCommand
         return new AutonomousCommand(
             driveSubsystem,
             autoPatternChooser,
             armSubsystem,
-            operatorInput);
+            operatorInput,
+            lightsSubsystem // Pass LightsSubsystem to AutonomousCommand
+        );
     }
 }

--- a/src/main/java/frc/robot/commands/arm/AmpShootCommand.java
+++ b/src/main/java/frc/robot/commands/arm/AmpShootCommand.java
@@ -39,7 +39,7 @@ public class AmpShootCommand extends BaseArmCommand {
     @Override
     public void execute() {
 
-        boolean atAngle = moveToTargetAngle(120.25); // WORKS!!! (after 1 hour of testing)
+        boolean atAngle = moveToTargetAngle(targetAngle);
 
         armSubsystem.setAmpSpeed(shootSpeed);
 

--- a/src/main/java/frc/robot/commands/arm/Constants.java
+++ b/src/main/java/frc/robot/commands/arm/Constants.java
@@ -200,17 +200,17 @@ public final class Constants {
         public static final double PIVOT_TO_ANGLE_PID_KI   = 0;
         public static final double PIVOT_TO_ANGLE_PID_KD   = 0;
 
-        public static final double AmpShootSpeed           = 0.3;
-        public static final double AmpPivotSpeed           = 0.2;
-        public static final double AmpTargetAngle          = 100;
+        public static final double AmpShootSpeed           = 0.24;
+        public static final double AmpPivotSpeed           = 0.3;
+        public static final double AmpTargetAngle          = 110;
         public static final double AmpTimeoutMS            = 4000;
 
-        public static final double LongSpeakerShootSpeed   = 0.5;
+        public static final double LongSpeakerShootSpeed   = 1;
         public static final double LongSpeakerPivotSpeed   = 0.2;
         public static final double LongSpeakerTargetAngle  = 60;
         public static final double LongSpeakerTimeoutMS    = 5000;
 
-        public static final double ShortSpeakerShootSpeed  = 0.5;
+        public static final double ShortSpeakerShootSpeed  = 1;
         public static final double ShortSpeakerPivotSpeed  = 0.2;
         public static final double ShortSpeakerTargetAngle = 90;
         public static final double ShortSpeakerTimeoutMS   = 4000;

--- a/src/main/java/frc/robot/commands/arm/IntakeCommand.java
+++ b/src/main/java/frc/robot/commands/arm/IntakeCommand.java
@@ -50,7 +50,7 @@ public class IntakeCommand extends BaseArmCommand {
         if (armSubsystem.isLoaded()) {
             if (!hasFlashed) {
                 // Start the white flashing effect for 3 seconds
-                lightsSubsystem.flashWhite();
+                lightsSubsystem.flashGreen();
                 flashTimer.start();
                 hasFlashed = true;
             }

--- a/src/main/java/frc/robot/commands/auto/AutonomousCommand.java
+++ b/src/main/java/frc/robot/commands/auto/AutonomousCommand.java
@@ -17,26 +17,27 @@ import frc.robot.commands.drive.TurnToHeadingCommand;
 import frc.robot.operator.OperatorInput;
 import frc.robot.subsystems.ArmSubsystem;
 import frc.robot.subsystems.DriveSubsystem;
+import frc.robot.subsystems.LightsSubsystem; // Import LightsSubsystem
 
 public class AutonomousCommand extends SequentialCommandGroup {
 
+    // Updated constructor with LightsSubsystem
     public AutonomousCommand(DriveSubsystem driveSubsystem,
-        SendableChooser<AutoPattern> autoPatternChooser, ArmSubsystem armSubsystem, OperatorInput operatorInput) {
+        SendableChooser<AutoPattern> autoPatternChooser,
+        ArmSubsystem armSubsystem,
+        OperatorInput operatorInput,
+        LightsSubsystem lightsSubsystem) { // Add LightsSubsystem
 
         // Default is to do nothing.
-        // If more commands are added, the instant command will end and
-        // the next command will be executed.
         addCommands(new InstantCommand());
 
         AutoPattern   autoPattern = autoPatternChooser.getSelected();
-
         Alliance      alliance    = DriverStation.getAlliance().orElse(null);
 
         StringBuilder sb          = new StringBuilder();
         sb.append("Auto Selections");
         sb.append("\n   Auto Pattern  : ").append(autoPattern);
         sb.append("\n   Alliance      : ").append(alliance);
-
         System.out.println(sb.toString());
 
         // If any inputs are null, then there was some kind of error.
@@ -45,425 +46,197 @@ public class AutonomousCommand extends SequentialCommandGroup {
             return;
         }
 
-        // Print an error if the alliance is not set
         if (alliance == null) {
             System.out.println("*** ERROR **** null Alliance ");
             return;
         }
 
         double startHeading;
+
         /*
-         * Compose the appropriate auto commands
+         * Compose the appropriate auto commands based on selected auto pattern
          */
         switch (autoPattern) {
 
         case DO_NOTHING:
         default:
-
             return;
 
         case DRIVE_FORWARD:
-
-
-            addCommands(new IntakeCommand(operatorInput, armSubsystem, true)
+            addCommands(new IntakeCommand(operatorInput, armSubsystem, lightsSubsystem, true) // Pass
+                                                                                              // LightsSubsystem
                 .alongWith(new MeasuredStraightDriveCommand(AutoConstants.AmpSideFirstStraightCM,
-                    AutoConstants.AmpSideDriveSpeed,
-                    true, driveSubsystem)));
-
+                    AutoConstants.AmpSideDriveSpeed, true, driveSubsystem)));
             break;
-
-
 
         case DRIVE_FORWARD_PID_TIMED:
-            // Drive forward for 30 seconds
-
             addCommands(new TimedStraightDriveCommand(1000, 1, true, 186, driveSubsystem));
-
             break;
-
-
 
         case DRIVE_FORWARD_PID_MEASURED:
-            // Drive forward for 10 meters
-
             addCommands(new MeasuredDriveAtHeadingCommand(100, 0.1, true, 355, driveSubsystem));
-
             break;
-
-
 
         case TEST_ARM_COMMANDS:
-            // program that will test the intake, pivot shoot, and pivot to angle
-
             addCommands(new MeasuredStraightDriveCommand(100, 0.2, true, driveSubsystem));
-
             addCommands(new PivotToAngleCommand(0.3, 30, 5000, armSubsystem));
-
-            addCommands(new IntakeCommand(operatorInput, armSubsystem, true));
-
-            addCommands(new IntakeCommand(operatorInput, armSubsystem, true));
-
-            // addCommands(new MeasuredStraightDriveCommand(100, 0.2, true, driveSubsystem));
-
-            // addCommands(new PivotToAngleCommand(0.3, 30, true, 10000, armSubsystem));
-
-            // addCommands(new IntakeCommand(0.5, 0.3, 10000, armSubsystem));
-
-            // addCommands(new PivotToAngleCommand(0.3, 30, true, 10000, armSubsystem));
-
-            // addCommands(new PivotShootCommand(1, 0.3, 90, 10000, armSubsystem));
-
+            addCommands(new IntakeCommand(operatorInput, armSubsystem, lightsSubsystem, true)); // Pass
+                                                                                                // LightsSubsystem
+            addCommands(new IntakeCommand(operatorInput, armSubsystem, lightsSubsystem, true)); // Pass
+                                                                                                // LightsSubsystem
             break;
-
-
 
         case BLUE_AMP_ONE_SHOT:
-            // From amp position, makes a speaker shot then leaves mobility zone
-
             startHeading = driveSubsystem.getHeading();
-
-            // makes first shot
-
             addCommands(new PivotShootCommand(AutoConstants.AmpSideShootSpeed,
                 AutoConstants.AmpSideShootAngle, AutoConstants.AmpSideTimeoutMS, armSubsystem));
-
-            // moves backwards
-
             addCommands(new MeasuredStraightDriveCommand(AutoConstants.AmpSideDiagStepCM,
-                AutoConstants.AmpSideDriveSpeed, true,
-                driveSubsystem).alongWith(new IntakeCommand(operatorInput, armSubsystem, true)));
-
-            // turns and leaves starting zone to get mobility points
-
+                AutoConstants.AmpSideDriveSpeed, true, driveSubsystem)
+                .alongWith(new IntakeCommand(operatorInput, armSubsystem, lightsSubsystem, true))); // Pass
+                                                                                                    // LightsSubsystem
             addCommands(new TurnToHeadingCommand(AutoConstants.AmpSideDriveSpeed,
-                startHeading + AutoConstants.AmpSideFirstAngle, true, AutoConstants.AmpSideTimeoutMS,
-                driveSubsystem));
-
-            addCommands(new IntakeCommand(operatorInput, armSubsystem, true)
+                startHeading + AutoConstants.AmpSideFirstAngle, true, AutoConstants.AmpSideTimeoutMS, driveSubsystem));
+            addCommands(new IntakeCommand(operatorInput, armSubsystem, lightsSubsystem, true)
                 .alongWith(new MeasuredStraightDriveCommand(AutoConstants.AmpSideFirstStraightCM,
-                    -AutoConstants.AmpSideDriveSpeed,
-                    true, driveSubsystem)));
-
+                    -AutoConstants.AmpSideDriveSpeed, true, driveSubsystem)));
             break;
-
-
 
         case RED_AMP_ONE_SHOT:
-            // From amp outside position, makes a speaker shot then leaves mobility zone
-
             startHeading = driveSubsystem.getHeading();
-
-            // first shot
-
             addCommands(new PivotShootCommand(AutoConstants.AmpSideShootSpeed,
                 AutoConstants.AmpSideShootAngle, AutoConstants.AmpSideTimeoutMS, armSubsystem));
-
-            // backing up
-
             addCommands(new MeasuredStraightDriveCommand(AutoConstants.AmpSideDiagStepCM,
-                AutoConstants.AmpSideDriveSpeed, true,
-                driveSubsystem).alongWith(new IntakeCommand(operatorInput, armSubsystem, true)));
-
-            // turns and drives towards first note while intaking
-
+                AutoConstants.AmpSideDriveSpeed, true, driveSubsystem)
+                .alongWith(new IntakeCommand(operatorInput, armSubsystem, lightsSubsystem, true))); // Pass
+                                                                                                    // LightsSubsystem
             addCommands(new TurnToHeadingCommand(AutoConstants.AmpSideDriveSpeed,
-                startHeading - AutoConstants.AmpSideFirstAngle, true, AutoConstants.AmpSideTimeoutMS,
-                driveSubsystem));
-
-            addCommands(new IntakeCommand(operatorInput, armSubsystem, true)
+                startHeading - AutoConstants.AmpSideFirstAngle, true, AutoConstants.AmpSideTimeoutMS, driveSubsystem));
+            addCommands(new IntakeCommand(operatorInput, armSubsystem, lightsSubsystem, true)
                 .alongWith(new MeasuredStraightDriveCommand(AutoConstants.AmpSideFirstStraightCM,
-                    -AutoConstants.AmpSideDriveSpeed,
-                    true, driveSubsystem)));
-
+                    -AutoConstants.AmpSideDriveSpeed, true, driveSubsystem)));
             break;
-
-
 
         case BLUE_OUTSIDE_ONE_SHOT:
-
-            // backs up to make a shot,
-            // then backs into mobility zone
-
-            addCommands(
-                new PivotShootCommand(AutoConstants.OutsideSideShooterSpeed, AutoConstants.OutsideSideShooterAngle,
-                    AutoConstants.OutsideSideTimeoutMS, armSubsystem));
-
-            addCommands(
-                new MeasuredStraightDriveCommand(AutoConstants.OutsideSideDiagStepCM,
-                    AutoConstants.OutsideSideDriveSpeed, true,
-                    driveSubsystem));
-
+            addCommands(new PivotShootCommand(AutoConstants.OutsideSideShooterSpeed,
+                AutoConstants.OutsideSideShooterAngle, AutoConstants.OutsideSideTimeoutMS, armSubsystem));
+            addCommands(new MeasuredStraightDriveCommand(AutoConstants.OutsideSideDiagStepCM,
+                AutoConstants.OutsideSideDriveSpeed, true, driveSubsystem));
             break;
-
-
 
         case RED_OUTSIDE_ONE_SHOT:
-
-            // backs up to make a shot,
-            // then backs into mobility zone
-
-            addCommands(
-                new PivotShootCommand(AutoConstants.OutsideSideShooterSpeed, AutoConstants.OutsideSideShooterAngle,
-                    AutoConstants.OutsideSideTimeoutMS, armSubsystem));
-
-            addCommands(
-                new MeasuredStraightDriveCommand(AutoConstants.OutsideSideDiagStepCM,
-                    AutoConstants.OutsideSideDriveSpeed, true,
-                    driveSubsystem));
-
+            addCommands(new PivotShootCommand(AutoConstants.OutsideSideShooterSpeed,
+                AutoConstants.OutsideSideShooterAngle, AutoConstants.OutsideSideTimeoutMS, armSubsystem));
+            addCommands(new MeasuredStraightDriveCommand(AutoConstants.OutsideSideDiagStepCM,
+                AutoConstants.OutsideSideDriveSpeed, true, driveSubsystem));
             break;
-
-
 
         case RED_SPEAKER_ONE_SHOT:
-
-            addCommands(
-                new PivotShootCommand(AutoConstants.SpeakerSideShootSpeed, AutoConstants.SpeakerSideShootAngle,
-                    AutoConstants.SpeakerSideTimeoutMS, armSubsystem));
-
-            addCommands(
-                new MeasuredStraightDriveCommand(AutoConstants.SpeakerSideDiagStepCM,
-                    AutoConstants.SpeakerSideDriveSpeed, true,
-                    driveSubsystem));
-
+            addCommands(new PivotShootCommand(AutoConstants.SpeakerSideShootSpeed,
+                AutoConstants.SpeakerSideShootAngle, AutoConstants.SpeakerSideTimeoutMS, armSubsystem));
+            addCommands(new MeasuredStraightDriveCommand(AutoConstants.SpeakerSideDiagStepCM,
+                AutoConstants.SpeakerSideDriveSpeed, true, driveSubsystem));
             break;
-
-
 
         case BLUE_SPEAKER_ONE_SHOT:
-
-            addCommands(
-                new PivotShootCommand(AutoConstants.SpeakerSideShootSpeed, AutoConstants.SpeakerSideShootAngle,
-                    AutoConstants.SpeakerSideTimeoutMS, armSubsystem));
-
-            addCommands(
-                new MeasuredStraightDriveCommand(AutoConstants.SpeakerSideDiagStepCM,
-                    AutoConstants.SpeakerSideDriveSpeed, true,
-                    driveSubsystem));
-
+            addCommands(new PivotShootCommand(AutoConstants.SpeakerSideShootSpeed,
+                AutoConstants.SpeakerSideShootAngle, AutoConstants.SpeakerSideTimeoutMS, armSubsystem));
+            addCommands(new MeasuredStraightDriveCommand(AutoConstants.SpeakerSideDiagStepCM,
+                AutoConstants.SpeakerSideDriveSpeed, true, driveSubsystem));
             break;
-
-
 
         case BLUE_AMP_TWO_SHOT:
-            // From outside position, makes a speaker and backs up
-            // then it turns goes backwards to get a note, goes forward and turns back to make
-            // another shot. starts at the edge of the subwoofer facing away from it
-
             startHeading = driveSubsystem.getHeading();
-
-            // first shot
-
             addCommands(new PivotShootCommand(AutoConstants.AmpSideShootSpeed,
                 AutoConstants.AmpSideShootAngle, AutoConstants.AmpSideTimeoutMS, armSubsystem));
-
-            // backing up
-
             addCommands(new MeasuredStraightDriveCommand(AutoConstants.AmpSideDiagStepCM,
-                AutoConstants.AmpSideDriveSpeed, true,
-                driveSubsystem).alongWith(new IntakeCommand(operatorInput, armSubsystem, true)));
-
-            // turns and drives towards first note while intaking
-
+                AutoConstants.AmpSideDriveSpeed, true, driveSubsystem)
+                .alongWith(new IntakeCommand(operatorInput, armSubsystem, lightsSubsystem, true))); // Pass
+                                                                                                    // LightsSubsystem
             addCommands(new TurnToHeadingCommand(AutoConstants.AmpSideDriveSpeed,
-                startHeading + AutoConstants.AmpSideFirstAngle, true, AutoConstants.AmpSideTimeoutMS,
-                driveSubsystem));
-
-            // Subtract 15 because return goes too far
+                startHeading + AutoConstants.AmpSideFirstAngle, true, AutoConstants.AmpSideTimeoutMS, driveSubsystem));
             addCommands(new MeasuredStraightDriveCommand(AutoConstants.AmpSideFirstStraightCM - 15,
-                AutoConstants.AmpSideDriveSpeed,
-                true, driveSubsystem).alongWith(new IntakeCommand(operatorInput, armSubsystem, true)));
-
-            // goes back to shooting place
-
-            // Add 10cm to the return distance to ensure that it is flush with the subwoofer
+                AutoConstants.AmpSideDriveSpeed, true, driveSubsystem)
+                .alongWith(new IntakeCommand(operatorInput, armSubsystem, lightsSubsystem, true))); // Pass
+                                                                                                    // LightsSubsystem
             addCommands(new MeasuredStraightDriveCommand(AutoConstants.AmpSideFirstStraightCM + 10,
-                -AutoConstants.AmpSideDriveSpeed,
-                true, driveSubsystem));
-
+                -AutoConstants.AmpSideDriveSpeed, true, driveSubsystem));
             addCommands(new TurnToHeadingCommand(AutoConstants.AmpSideDriveSpeed,
-                startHeading, true, AutoConstants.AmpSideTimeoutMS,
-                driveSubsystem));
-
+                startHeading, true, AutoConstants.AmpSideTimeoutMS, driveSubsystem));
             addCommands(new MeasuredStraightDriveCommand(AutoConstants.AmpSideDiagStepCM,
-                -AutoConstants.AmpSideDriveSpeed, true,
-                driveSubsystem));
-
-            // second shot
-
+                -AutoConstants.AmpSideDriveSpeed, true, driveSubsystem));
             addCommands(new PivotShootCommand(AutoConstants.AmpSideShootSpeed,
                 AutoConstants.AmpSideShootAngle, AutoConstants.AmpSideTimeoutMS, armSubsystem));
-
-            // turns and leaves starting zone to get mobility points
-
             addCommands(new MeasuredStraightDriveCommand(AutoConstants.AmpSideDiagStepCM,
-                -AutoConstants.AmpSideDriveSpeed, true,
-                driveSubsystem));
-
+                -AutoConstants.AmpSideDriveSpeed, true, driveSubsystem));
             addCommands(new TurnToHeadingCommand(AutoConstants.AmpSideDriveSpeed,
-                startHeading + AutoConstants.AmpSideFirstAngle, true, AutoConstants.AmpSideTimeoutMS,
-                driveSubsystem));
-
-            addCommands(
-                new MeasuredStraightDriveCommand(AutoConstants.AmpSideFirstStraightCM,
-                    AutoConstants.AmpSideDriveSpeed, true,
-                    driveSubsystem));
-
+                startHeading + AutoConstants.AmpSideFirstAngle, true, AutoConstants.AmpSideTimeoutMS, driveSubsystem));
+            addCommands(new MeasuredStraightDriveCommand(AutoConstants.AmpSideFirstStraightCM,
+                AutoConstants.AmpSideDriveSpeed, true, driveSubsystem));
             break;
-
 
         case RED_AMP_TWO_SHOT:
-            // From outside position, backs up and makes a speaker shot
-            // then it turns goes backwards to get a note, goes forward and turns back to make
-            // another shot. starts at the edge of the subwoofer facing away from it
-
             startHeading = driveSubsystem.getHeading();
-
-            // first shot
-
             addCommands(new PivotShootCommand(AutoConstants.AmpSideShootSpeed,
                 AutoConstants.AmpSideShootAngle, AutoConstants.AmpSideTimeoutMS, armSubsystem));
-
-            // backing up
-
             addCommands(new MeasuredStraightDriveCommand(AutoConstants.AmpSideDiagStepCM + 10,
-                AutoConstants.AmpSideDriveSpeed, true,
-                driveSubsystem).alongWith(new IntakeCommand(operatorInput, armSubsystem, true)));
-            // turns and drives towards first note while intaking
-
+                AutoConstants.AmpSideDriveSpeed, true, driveSubsystem)
+                .alongWith(new IntakeCommand(operatorInput, armSubsystem, lightsSubsystem, true))); // Pass
+                                                                                                    // LightsSubsystem
             addCommands(new TurnToHeadingCommand(AutoConstants.AmpSideDriveSpeed,
-                startHeading - AutoConstants.AmpSideFirstAngle, true, AutoConstants.AmpSideTimeoutMS,
-                driveSubsystem));
-
-
+                startHeading - AutoConstants.AmpSideFirstAngle, true, AutoConstants.AmpSideTimeoutMS, driveSubsystem));
             addCommands(new MeasuredStraightDriveCommand(AutoConstants.AmpSideFirstStraightCM,
-                AutoConstants.AmpSideDriveSpeed,
-                true, driveSubsystem).alongWith(new IntakeCommand(operatorInput, armSubsystem, true)));
-
-            // goes back to shooting place
-
+                AutoConstants.AmpSideDriveSpeed, true, driveSubsystem)
+                .alongWith(new IntakeCommand(operatorInput, armSubsystem, lightsSubsystem, true))); // Pass
+                                                                                                    // LightsSubsystem
             addCommands(new MeasuredStraightDriveCommand(AutoConstants.AmpSideFirstStraightCM - 15,
-                -AutoConstants.AmpSideDriveSpeed,
-                true, driveSubsystem));
-
+                -AutoConstants.AmpSideDriveSpeed, true, driveSubsystem));
             addCommands(new TurnToHeadingCommand(AutoConstants.AmpSideDriveSpeed,
-                startHeading - 10, true, AutoConstants.AmpSideTimeoutMS,
-                driveSubsystem));
-
-            // Add 50cm to the return distance to ensure that it is flush with the subwoofer
+                startHeading - 10, true, AutoConstants.AmpSideTimeoutMS, driveSubsystem));
             addCommands(new MeasuredStraightDriveCommand(AutoConstants.AmpSideDiagStepCM + 50,
-                -AutoConstants.AmpSideDriveSpeed, true,
-                driveSubsystem));
-
-            // second shot
-
+                -AutoConstants.AmpSideDriveSpeed, true, driveSubsystem));
             addCommands(new PivotShootCommand(AutoConstants.AmpSideShootSpeed,
                 AutoConstants.AmpSideShootAngle, AutoConstants.AmpSideTimeoutMS, armSubsystem));
-
-            // turns and leaves starting zone to get mobility points
-
             addCommands(new MeasuredStraightDriveCommand(AutoConstants.AmpSideDiagStepCM,
-                -AutoConstants.AmpSideDriveSpeed, true,
-                driveSubsystem));
-
+                -AutoConstants.AmpSideDriveSpeed, true, driveSubsystem));
             addCommands(new TurnToHeadingCommand(AutoConstants.AmpSideDriveSpeed,
-                startHeading - AutoConstants.AmpSideFirstAngle, true, AutoConstants.AmpSideTimeoutMS,
-                driveSubsystem));
-
-            addCommands(
-                new MeasuredStraightDriveCommand(AutoConstants.AmpSideFirstStraightCM,
-                    AutoConstants.AmpSideDriveSpeed, true,
-                    driveSubsystem));
-
+                startHeading - AutoConstants.AmpSideFirstAngle, true, AutoConstants.AmpSideTimeoutMS, driveSubsystem));
+            addCommands(new MeasuredStraightDriveCommand(AutoConstants.AmpSideFirstStraightCM,
+                AutoConstants.AmpSideDriveSpeed, true, driveSubsystem));
             break;
-
-
 
         case BLUE_SPEAKER_TWO_SHOT:
-
-            // first shot
-
-            addCommands(
-                new PivotShootCommand(AutoConstants.SpeakerSideShootSpeed, AutoConstants.SpeakerSideShootAngle,
-                    AutoConstants.SpeakerSideTimeoutMS, armSubsystem));
-
-            // backs up while intaking
-
-            addCommands(new IntakeCommand(operatorInput, armSubsystem, true));
-
-            addCommands(
-                new MeasuredStraightDriveCommand(AutoConstants.SpeakerSideDiagStepCM,
-                    AutoConstants.SpeakerSideDriveSpeed, true,
-                    driveSubsystem).alongWith(new IntakeCommand(operatorInput, armSubsystem, true)));
-
-            // goes back
-
-            addCommands(
-                new MeasuredStraightDriveCommand(AutoConstants.SpeakerSideDiagStepCM,
-                    -AutoConstants.SpeakerSideDriveSpeed, true,
-                    driveSubsystem));
-
-            // second shot
-
-            addCommands(
-                new PivotShootCommand(AutoConstants.SpeakerSideShootSpeed, AutoConstants.SpeakerSideShootAngle,
-                    AutoConstants.SpeakerSideTimeoutMS, armSubsystem));
-
-            // goes to get mobility points
-
-            addCommands(
-                new MeasuredStraightDriveCommand(AutoConstants.SpeakerSideDiagStepCM,
-                    AutoConstants.SpeakerSideDriveSpeed, true,
-                    driveSubsystem));
-
-
+            addCommands(new PivotShootCommand(AutoConstants.SpeakerSideShootSpeed,
+                AutoConstants.SpeakerSideShootAngle, AutoConstants.SpeakerSideTimeoutMS, armSubsystem));
+            addCommands(new IntakeCommand(operatorInput, armSubsystem, lightsSubsystem, true)); // Pass
+                                                                                                // LightsSubsystem
+            addCommands(new MeasuredStraightDriveCommand(AutoConstants.SpeakerSideDiagStepCM,
+                AutoConstants.SpeakerSideDriveSpeed, true, driveSubsystem)
+                .alongWith(new IntakeCommand(operatorInput, armSubsystem, lightsSubsystem, true))); // Pass
+                                                                                                    // LightsSubsystem
+            addCommands(new MeasuredStraightDriveCommand(AutoConstants.SpeakerSideDiagStepCM,
+                -AutoConstants.SpeakerSideDriveSpeed, true, driveSubsystem));
+            addCommands(new PivotShootCommand(AutoConstants.SpeakerSideShootSpeed,
+                AutoConstants.SpeakerSideShootAngle, AutoConstants.SpeakerSideTimeoutMS, armSubsystem));
+            addCommands(new MeasuredStraightDriveCommand(AutoConstants.SpeakerSideDiagStepCM,
+                AutoConstants.SpeakerSideDriveSpeed, true, driveSubsystem));
             break;
-
-
 
         case RED_SPEAKER_TWO_SHOT:
-
-            // first shot
-
-            addCommands(
-                new PivotShootCommand(AutoConstants.SpeakerSideShootSpeed, AutoConstants.SpeakerSideShootAngle,
-                    AutoConstants.SpeakerSideTimeoutMS, armSubsystem));
-
-            // backs up while intaking
-
-            addCommands(new IntakeCommand(operatorInput, armSubsystem, true));
-
-            addCommands(
-                new MeasuredStraightDriveCommand(AutoConstants.SpeakerSideDiagStepCM,
-                    AutoConstants.SpeakerSideDriveSpeed, true,
-                    driveSubsystem).alongWith(new IntakeCommand(operatorInput, armSubsystem, true)));
-
-            // goes back
-
-            addCommands(
-                new MeasuredStraightDriveCommand(AutoConstants.SpeakerSideDiagStepCM,
-                    -AutoConstants.SpeakerSideDriveSpeed, true,
-                    driveSubsystem));
-
-            // second shot
-
-            addCommands(
-                new PivotShootCommand(AutoConstants.SpeakerSideShootSpeed, AutoConstants.SpeakerSideShootAngle,
-                    AutoConstants.SpeakerSideTimeoutMS, armSubsystem));
-
-            // goes to get mobility points
-
-            addCommands(
-                new MeasuredStraightDriveCommand(AutoConstants.SpeakerSideDiagStepCM,
-                    AutoConstants.SpeakerSideDriveSpeed, true,
-                    driveSubsystem));
-
-
+            addCommands(new PivotShootCommand(AutoConstants.SpeakerSideShootSpeed,
+                AutoConstants.SpeakerSideShootAngle, AutoConstants.SpeakerSideTimeoutMS, armSubsystem));
+            addCommands(new IntakeCommand(operatorInput, armSubsystem, lightsSubsystem, true)); // Pass
+                                                                                                // LightsSubsystem
+            addCommands(new MeasuredStraightDriveCommand(AutoConstants.SpeakerSideDiagStepCM,
+                AutoConstants.SpeakerSideDriveSpeed, true, driveSubsystem)
+                .alongWith(new IntakeCommand(operatorInput, armSubsystem, lightsSubsystem, true))); // Pass
+                                                                                                    // LightsSubsystem
+            addCommands(new MeasuredStraightDriveCommand(AutoConstants.SpeakerSideDiagStepCM,
+                -AutoConstants.SpeakerSideDriveSpeed, true, driveSubsystem));
+            addCommands(new PivotShootCommand(AutoConstants.SpeakerSideShootSpeed,
+                AutoConstants.SpeakerSideShootAngle, AutoConstants.SpeakerSideTimeoutMS, armSubsystem));
+            addCommands(new MeasuredStraightDriveCommand(AutoConstants.SpeakerSideDiagStepCM,
+                AutoConstants.SpeakerSideDriveSpeed, true, driveSubsystem));
             break;
-
-
-
         }
     }
 }
-

--- a/src/main/java/frc/robot/operator/OperatorInput.java
+++ b/src/main/java/frc/robot/operator/OperatorInput.java
@@ -18,13 +18,13 @@ import frc.robot.commands.drive.TimedStraightDriveCommand;
 import frc.robot.subsystems.ArmSubsystem;
 import frc.robot.subsystems.ClimbSubsystem;
 import frc.robot.subsystems.DriveSubsystem;
-
+import frc.robot.subsystems.LightsSubsystem;
 
 /**
  * The Operator input class is used to map buttons to functions and functions to commands
  * <p>
  * This class extends SubsystemBase so that the periodic() routine is called each loop. The periodic
- * routine can be used to send debug information to the dashboard
+ * routine can be used to send debug information to the dashboard.
  */
 public class OperatorInput extends SubsystemBase {
 
@@ -42,22 +42,16 @@ public class OperatorInput extends SubsystemBase {
 
     /*
      * Map all functions to buttons.
-     *
      * A function should be a description of the robot behavior it is triggering.
-     *
-     * This separation of concerns allows for remapping of the robot functions to different
-     * controller buttons without the need to change the command or the trigger. The mapping
-     * from controller button to function is done in the following methods.
      */
 
-    // Cancel all commands when the driver presses the XBox controller three lines (aka. start)
+    // Cancel all commands when the driver presses the Xbox controller three lines (aka. start)
     // button
     public boolean isCancel() {
         return driverController.getStartButton();
     }
 
     // drive methods
-
     public boolean getBoost() {
         return driverController.getLeftBumper();
     }
@@ -78,11 +72,8 @@ public class OperatorInput extends SubsystemBase {
         return driverController.getRightX();
     }
 
-
     public double getDriverControllerAxis(Stick stick, Axis axis) {
-
         switch (stick) {
-
         case LEFT:
             switch (axis) {
             case X:
@@ -101,21 +92,16 @@ public class OperatorInput extends SubsystemBase {
             }
             break;
         }
-
         return 0;
     }
 
     public double getSpeed(DriveMode driveMode) {
-
         return getDriverControllerAxis(Stick.LEFT, Axis.Y);
     }
 
     public double getTurn(DriveMode driveMode) {
-
         double turn = 0;
-
         switch (driveMode) {
-
         case SINGLE_STICK_ARCADE:
             turn = getDriverControllerAxis(Stick.LEFT, Axis.X);
             break;
@@ -125,7 +111,6 @@ public class OperatorInput extends SubsystemBase {
             turn = getDriverControllerAxis(Stick.RIGHT, Axis.X);
             break;
         }
-
         return turn;
     }
 
@@ -138,19 +123,12 @@ public class OperatorInput extends SubsystemBase {
     }
 
     // arm methods
-
     public boolean isIntake() {
-        if (driverController.getLeftTriggerAxis() >= 0.5) {
-            return true;
-        }
-        return false;
+        return driverController.getLeftTriggerAxis() >= 0.5;
     }
 
     public boolean isShootFront() {
-        if (driverController.getRightTriggerAxis() >= 0.5) {
-            return true;
-        }
-        return false;
+        return driverController.getRightTriggerAxis() >= 0.5;
     }
 
     public boolean isShootBack() {
@@ -174,7 +152,6 @@ public class OperatorInput extends SubsystemBase {
     }
 
     // climber methods
-
     public boolean isLowerClimbers() {
         return driverController.getAButton();
     }
@@ -187,70 +164,54 @@ public class OperatorInput extends SubsystemBase {
         return driverController.getPOV() == 90; // Right D-Pad
     }
 
-
     /**
      * Use this method to define your robotFunction -> command mappings.
-     *
      * NOTE: all subsystems should be passed into this method.
      */
-    public void configureButtonBindings(DriveSubsystem driveSubsystem, ArmSubsystem armSubsystem, ClimbSubsystem climbSubsystem) {
+    public void configureButtonBindings(DriveSubsystem driveSubsystem, ArmSubsystem armSubsystem, ClimbSubsystem climbSubsystem,
+        LightsSubsystem lightsSubsystem) { // Add LightsSubsystem
 
         new Trigger(() -> isCancel())
-
             .onTrue(new CancelCommand(this, driveSubsystem));
 
         new Trigger(() -> isIntake())
-
-            .onTrue(new IntakeCommand(this, armSubsystem, false));
+            .onTrue(new IntakeCommand(this, armSubsystem, lightsSubsystem, false)); // Pass
+                                                                                    // LightsSubsystem
+                                                                                    // to
+                                                                                    // IntakeCommand
 
         new Trigger(() -> isShootBack())
-
             .onTrue(new PivotShootCommand(1, 115, 5000, armSubsystem));
 
         new Trigger(() -> isShootFront())
-
             .onTrue(new PivotShootCommand(1, 65, 5000, armSubsystem));
 
         new Trigger(() -> isLowerClimbers())
-
             .onTrue(new LowerBothClimbersCommand(climbSubsystem, this));
 
         new Trigger(() -> isRaiseClimbers())
-
             .onTrue(new RaiseBothClimbersCommand(climbSubsystem, this));
 
         new Trigger(() -> isAmpShot())
-
-            // 108, 0.25
-            .onTrue(
-                new AmpShootCommand(0.4, 112, 5000, armSubsystem)
-                    .deadlineWith(new TimedStraightDriveCommand(10000, -0.1, true, driveSubsystem.getHeading(), driveSubsystem)));
+            .onTrue(new AmpShootCommand(0.4, 112, 5000, armSubsystem)
+                .deadlineWith(new TimedStraightDriveCommand(10000, -0.1, true, driveSubsystem.getHeading(), driveSubsystem)));
 
         new Trigger(() -> isShoot())
-
             .onTrue(new ShootCommand(1, armSubsystem));
 
         new Trigger(() -> isPivotUp())
-
             .onTrue(new ManualShootCommand(1, 3000, armSubsystem, this));
 
         new Trigger(() -> isPivotDown())
-
             .onTrue(new ManualShootCommand(1, 3000, armSubsystem, this));
 
         new Trigger(() -> isLongShot())
             .onTrue(new LongShotCommand(1, 40, armSubsystem));
-
-
-
     }
 
     @Override
     public void periodic() {
-
         // Display any operator input values on the smart dashboard.
-
         SmartDashboard.putString("Driver Controller", driverController.toString());
     }
-
 }

--- a/src/main/java/frc/robot/subsystems/LightsSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/LightsSubsystem.java
@@ -1,8 +1,11 @@
 package frc.robot.subsystems;
 
+import java.util.Optional;
+
 import edu.wpi.first.cameraserver.CameraServer;
 import edu.wpi.first.wpilibj.AddressableLED;
 import edu.wpi.first.wpilibj.AddressableLEDBuffer;
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.util.Color;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
@@ -11,97 +14,210 @@ import frc.robot.Constants.LightConstants;
 import frc.robot.Constants.OperatorConstants;
 import frc.robot.operator.GameController;
 
-
 public class LightsSubsystem extends SubsystemBase {
 
-   // define lights
-   private final AddressableLED              ledStrip           = new AddressableLED(LightConstants.LED_STRIP_PWM_PORT);
-   private final AddressableLEDBuffer        ledBuffer          = new AddressableLEDBuffer(LightConstants.LED_STRIP_LENGTH);
+   // Define lights
+   private final AddressableLED              ledStrip             = new AddressableLED(LightConstants.LED_STRIP_PWM_PORT);
+   private final AddressableLEDBuffer        ledBuffer            = new AddressableLEDBuffer(LightConstants.LED_STRIP_LENGTH);
 
-   private static final AddressableLEDBuffer RSL_OFF            = new AddressableLEDBuffer(LightConstants.LED_STRIP_LENGTH);
-   private static final AddressableLEDBuffer RSL_ON             = new AddressableLEDBuffer(LightConstants.LED_STRIP_LENGTH);
+   private static final AddressableLEDBuffer RSL_OFF              = new AddressableLEDBuffer(LightConstants.LED_STRIP_LENGTH);
+   private static final AddressableLEDBuffer RSL_ON               = new AddressableLEDBuffer(LightConstants.LED_STRIP_LENGTH);
 
-   // Colours
-   private static final Color                RSL_COLOR          = new Color(250, 21, 0);
-   private static final Color                BOOST_COLOR        = new Color(0, 0, 127);
-   private static final Color                TANK_COLOR         = new Color(0, 255, 0);
-   private static final Color                DUAL_STICK_COLOR   = new Color(0, 255, 255);
-   private static final Color                SINGLE_STICK_COLOR = new Color(255, 255, 0);
-   private static final Color                NON_BOOST_COLOR    = new Color(0, 0, 255);
-   private static final Color                NO_SPEED_COLOR     = new Color(255, 255, 255);
-   private static final Color                NOTHING_COLOR      = new Color(0, 0, 0);
+   // Colors
+   private static final Color                RSL_COLOR            = new Color(250, 21, 0);
+   private static final Color                BOOST_COLOR          = new Color(0, 0, 127);
+   private static final Color                TANK_COLOR           = new Color(0, 255, 0);
+   private static final Color                DUAL_STICK_COLOR     = new Color(0, 255, 255);
+   private static final Color                SINGLE_STICK_COLOR   = new Color(255, 255, 0);
+   private static final Color                NON_BOOST_COLOR      = new Color(0, 0, 255);
+   private static final Color                NO_SPEED_COLOR       = new Color(255, 255, 255);
+   private static final Color                NOTHING_COLOR        = new Color(0, 0, 0);
+   private static final Color                INTAKING_COLOR       = new Color(255, 140, 0);
+   private static final Color                NOTE_INTOOK_COLOR    = new Color(255, 255, 255);
+   private static final Color                POSESSION_COLOR      = new Color(0, 255, 0);
+   private static final int                  TRAIL_LENGTH         = 5;
 
 
-   private int                               rslFlashCount      = -1;
-   private boolean                           prevRSLOn          = false;
 
-   // game controller
-   public final GameController               driverController   = new GameController(
+   private boolean                           driveVisualization   = false;
+   private int                               rslFlashCount        = -1;
+   private boolean                           prevRSLOn            = false;
+   private int                               rainbowFirstPixelHue = 0;
+   private int                               knightFrontIndex     = 0;
+   private int                               knightBackIndex      = 29;
+   private boolean                           knightFrontDirection = true;
+   private boolean                           knightBackDirection  = false;
+
+   // Game controller
+   public final GameController               driverController     = new GameController(
       OperatorConstants.DRIVER_CONTROLLER_PORT,
       OperatorConstants.GAME_CONTROLLER_STICK_DEADBAND);
 
    static {
       // Initialize the RSL buffers
       for (int i = 0; i < LightConstants.LED_STRIP_LENGTH; i++) {
-         RSL_ON.setLED(i, RSL_COLOR);
+         RSL_ON.setLED(i, new Color(250, 21, 0));
          RSL_OFF.setLED(i, Color.kBlack);
       }
    }
 
    public LightsSubsystem() {
-
       // Start with all LEDs at a medium grey (not too blinding)
       ledStrip.setLength(LightConstants.LED_STRIP_LENGTH);
-      setAllLEDs(new Color(250, 21, 0));
+      setAllLEDs(Color.kBlack); // Start with all LEDs off
       ledStrip.start();
 
-      // Add the carmera here
+      // Add the camera here
       CameraServer.startAutomaticCapture();
-
    }
 
    public void setEnabled() {
-
-      // When the robot is first enabled flash the LEDs with the robot RSL for 5 flashes
+      // When the robot is first enabled, flash the LEDs with the robot RSL for 5 flashes
       rslFlashCount = 5;
    }
 
    @Override
    public void periodic() {
-
       // Flash all lights in time with the RSL when the robot is first enabled
       if (rslFlashCount >= 0) {
          flashRSL();
+      }
+
+      if (!DriverStation.isEnabled()) {
+         runKnightRiderEffect();
+      }
+      else {
+         setAllianceColorOrRainbow(); // Default alliance color or rainbow effect when enabled
       }
 
       // Ensure the data is always sent to the strip, even if not flashing
       ledStrip.setData(ledBuffer);
    }
 
-   private void clear() {
-      for (int i = 0; i < LightConstants.LED_STRIP_LENGTH; i++) {
-         ledBuffer.setLED(i, RSL_COLOR);
+   // LED tron effect
+   // Front section moves left to right, Back section moves right to left
+   public void runKnightRiderEffect() {
+      // Set all LEDs to the background color first (black/off)
+      setAllLEDs(Color.kBlack);
+
+      // Draw the trail for the front section (LEDs 0-29)
+      drawKnightRiderTrail(knightFrontIndex, 0, knightFrontDirection);
+
+      // Draw the trail for the back section (LEDs 30-59)
+      drawKnightRiderTrail(knightBackIndex, 30, knightBackDirection);
+
+      // Update the knightFrontIndex for the front section movement
+      if (knightFrontDirection) {
+         knightFrontIndex++;
+         if (knightFrontIndex >= 29) {
+            knightFrontDirection = false; // Change direction at the end of the front section
+         }
+      }
+      else {
+         knightFrontIndex--;
+         if (knightFrontIndex <= 0) {
+            knightFrontDirection = true; // Change direction at the beginning of the front section
+         }
+      }
+
+      // Update the knightBackIndex for the back section movement
+      if (knightBackDirection) {
+         knightBackIndex++;
+         if (knightBackIndex >= 29) {
+            knightBackDirection = false; // Change direction at the end of the back section
+         }
+      }
+      else {
+         knightBackIndex--;
+         if (knightBackIndex <= 0) {
+            knightBackDirection = true; // Change direction at the beginning of the back section
+         }
+      }
+
+      ledStrip.setData(ledBuffer);
+   }
+
+   // LED bouncing effect
+   // index is the current "main" LED position, offset is the starting position for the section
+   // direction controls whether the LEDs move forward or backward
+   private void drawKnightRiderTrail(int index, int offset, boolean direction) {
+      for (int i = 0; i < TRAIL_LENGTH; i++) {
+         int ledIndex = direction ? index - i : index + i; // Adjust index for trail
+         if (ledIndex >= 0 && ledIndex < 30) { // Only set LEDs within the section
+            int brightness = 255 - (i * (255 / TRAIL_LENGTH)); // Decrease brightness for the trail
+            ledBuffer.setLED(offset + ledIndex, Color.fromHSV(0, 255, brightness));
+         }
       }
    }
 
-   private void setAllLEDs(Color color) {
+   // Method to turn LEDs orange while intaking
+   public void setIntakingColor() {
+      setAllLEDs(INTAKING_COLOR);
+   }
 
+   // Method to flash white for a note intake
+   public void flashWhite() {
+      setAllLEDs(NOTE_INTOOK_COLOR);
+   }
+
+   // Method to set LEDs green when the robot is holding a note
+   public void setPossessionColor() {
+      setAllLEDs(POSESSION_COLOR);
+   }
+
+   // Method to run a rainbow wave effect
+   public void runRainbow() {
+      for (int i = 0; i < ledBuffer.getLength(); i++) {
+         // Calculate the hue for this pixel. The hue is offset by the pixel's position
+         int hue = (rainbowFirstPixelHue + (i * 180 / ledBuffer.getLength())) % 180;
+         ledBuffer.setLED(i, Color.fromHSV(hue, 255, 128));
+      }
+
+      // Increment the first pixel hue to create the wave effect
+      rainbowFirstPixelHue += 3;
+      rainbowFirstPixelHue %= 180; // Reset after a full cycle
+      ledStrip.setData(ledBuffer);
+   }
+
+   // Set lights based on the alliance color or rainbow if no alliance
+   public void setAllianceColorOrRainbow() {
+      Optional<DriverStation.Alliance> allianceOptional = DriverStation.getAlliance();
+
+      if (allianceOptional.isPresent()) {
+         DriverStation.Alliance alliance = allianceOptional.get();
+         if (alliance == DriverStation.Alliance.Red) {
+            setAllLEDs(Color.kRed);
+         }
+         else if (alliance == DriverStation.Alliance.Blue) {
+            setAllLEDs(Color.kBlue);
+         }
+         else {
+            runRainbow();
+         }
+      }
+      else {
+         runRainbow();
+      }
+   }
+
+   // Method to turn off lights
+   public void turnOffLights() {
+      setAllLEDs(NOTHING_COLOR);
+   }
+
+   // Utility to set all LEDs to the same color
+   private void setAllLEDs(Color color) {
       for (int i = 0; i < LightConstants.LED_STRIP_LENGTH; i++) {
          ledBuffer.setLED(i, color);
       }
-   }
-
-   private void setLED(int index, Color color) {
-      ledBuffer.setLED(index, color);
+      ledStrip.setData(ledBuffer);
    }
 
    private void flashRSL() {
-
       // Flash in time with the RSL light
       boolean rslOn = RobotController.getRSLState();
 
-      // when the RSL changes from on to off, then
-      // update the RSL count.
+      // When the RSL changes from on to off, then update the RSL count
       if (prevRSLOn && !rslOn) {
          rslFlashCount--;
       }
@@ -117,9 +233,12 @@ public class LightsSubsystem extends SubsystemBase {
    }
 
    public void ledStick(boolean boost, DriveMode driveMode) {
+      if (!driveVisualization) {
+         return; // Skip if drive visualization is disabled
+      }
 
-      int    leftMidPoint  = (int) 15;
-      int    rightMidPoint = (int) 45;
+      int    leftMidPoint  = 15;
+      int    rightMidPoint = 45;
 
       double leftStickY    = driverController.getLeftY();
       double leftStickX    = driverController.getLeftX();
@@ -129,49 +248,45 @@ public class LightsSubsystem extends SubsystemBase {
       int    upToLeft;
       int    upToRight;
       switch (driveMode) {
-
       case SINGLE_STICK_ARCADE:
          upToLeft = (int) Math.round(leftMidPoint * (1 - leftStickY));
          upToRight = (int) Math.round(rightMidPoint + leftMidPoint * leftStickX);
-
          for (int i = Math.min(upToLeft, leftMidPoint); i == Math.max(upToLeft, leftMidPoint); i++) {
             ledBuffer.setLED(i, SINGLE_STICK_COLOR);
          }
-
          if (boost) {
             ledBuffer.setLED(LightConstants.BOOST_INDEX, BOOST_COLOR);
          }
          else {
             ledBuffer.setLED(LightConstants.BOOST_INDEX, NOTHING_COLOR);
          }
-         break; // Added break
+         break;
 
       case DUAL_STICK_ARCADE:
       default:
-
          upToLeft = (int) Math.round(leftMidPoint - (leftStickY * LightConstants.LED_STICK_TAKEN_LENGTH));
          upToRight = (int) Math.round(rightMidPoint + (rightStickX * LightConstants.LED_STICK_TAKEN_LENGTH));
 
-         for (int i = (leftMidPoint - LightConstants.LED_STICK_TAKEN_LENGTH + 1); i < leftMidPoint
+         for (int i = leftMidPoint - LightConstants.LED_STICK_TAKEN_LENGTH + 1; i < leftMidPoint
             + LightConstants.LED_STICK_TAKEN_LENGTH; i++) {
             ledBuffer.setLED(i, NOTHING_COLOR);
          }
-         int Adder;
-         Adder = (leftMidPoint - upToLeft);
-         if (Adder != 0) {
-            for (int i = leftMidPoint; i != upToLeft; i = i - (Adder / Math.abs(Adder))) {
+
+         int adder = leftMidPoint - upToLeft;
+         if (adder != 0) {
+            for (int i = leftMidPoint; i != upToLeft; i = i - (adder / Math.abs(adder))) {
                ledBuffer.setLED(i, DUAL_STICK_COLOR);
             }
          }
 
-         for (int i = (rightMidPoint - LightConstants.LED_STICK_TAKEN_LENGTH + 1); i < rightMidPoint
+         for (int i = rightMidPoint - LightConstants.LED_STICK_TAKEN_LENGTH + 1; i < rightMidPoint
             + LightConstants.LED_STICK_TAKEN_LENGTH; i++) {
             ledBuffer.setLED(i - 1, NOTHING_COLOR);
          }
 
-         Adder = (rightMidPoint - upToRight);
-         if (Adder != 0) {
-            for (int i = rightMidPoint; i != upToRight; i = i - (Adder / Math.abs(Adder))) {
+         adder = rightMidPoint - upToRight;
+         if (adder != 0) {
+            for (int i = rightMidPoint; i != upToRight; i = i - (adder / Math.abs(adder))) {
                ledBuffer.setLED(i - 1, DUAL_STICK_COLOR);
             }
          }
@@ -182,16 +297,9 @@ public class LightsSubsystem extends SubsystemBase {
          else {
             ledBuffer.setLED(LightConstants.BOOST_INDEX, NOTHING_COLOR);
          }
-         break; // Added break
-
-      case TANK:
-         // Add logic for TANK mode if needed
-         break; // Added break
-
+         break;
       }
 
-      // Ensure the LED data is sent after updating the buffer
       ledStrip.setData(ledBuffer);
    }
-
 }

--- a/src/main/java/frc/robot/subsystems/LightsSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/LightsSubsystem.java
@@ -33,7 +33,7 @@ public class LightsSubsystem extends SubsystemBase {
    private static final Color                NO_SPEED_COLOR       = new Color(255, 255, 255);
    private static final Color                NOTHING_COLOR        = new Color(0, 0, 0);
    private static final Color                INTAKING_COLOR       = new Color(255, 140, 0);
-   private static final Color                NOTE_INTOOK_COLOR    = new Color(255, 255, 255);
+   private static final Color                NOTE_INTOOK_COLOR    = new Color(0, 255, 0);
    private static final Color                POSESSION_COLOR      = new Color(0, 255, 0);
 
    // General Variables
@@ -192,9 +192,29 @@ public class LightsSubsystem extends SubsystemBase {
       setAllLEDs(INTAKING_COLOR);
    }
 
-   // Method to flash white for a note intake
-   public void flashWhite() {
-      setAllLEDs(NOTE_INTOOK_COLOR);
+   // Method to flash green when a note is first collected
+   public void flashGreen() {
+      for (int flashCount = 0; flashCount < 3; flashCount++) {
+         // Set all LEDs to green
+         setAllLEDs(NOTE_INTOOK_COLOR);
+         ledStrip.setData(ledBuffer);
+         try {
+            Thread.sleep(100); // 100ms on
+         }
+         catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+         }
+
+         // Turn off the LEDs
+         setAllLEDs(NOTHING_COLOR);
+         ledStrip.setData(ledBuffer);
+         try {
+            Thread.sleep(100); // 100ms off
+         }
+         catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+         }
+      }
    }
 
    // Method to set LEDs green when the robot is holding a note

--- a/src/main/java/frc/robot/subsystems/LightsSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/LightsSubsystem.java
@@ -182,9 +182,7 @@ public class LightsSubsystem extends SubsystemBase {
          int ledIndex = direction ? index - i : index + i; // Adjust index for trail
          if (ledIndex >= 0 && ledIndex < 30) { // Only set LEDs within the section
             int brightness = 255 - (i * (255 / TRAIL_LENGTH)); // Decrease brightness for the trail
-            ledBuffer.setLED(offset + ledIndex, Color.fromHSV(0, 255, brightness)); // Red hue with
-                                                                                    // fading
-                                                                                    // brightness
+            ledBuffer.setLED(offset + ledIndex, Color.fromHSV(0, 255, brightness));
          }
       }
    }


### PR DESCRIPTION
Added driver feedback through LED lights. Lights will play a Knight rider style animation when the robot is idle. The LEDs will indicate current alliance colour as a default state while enabled. When intaking, the lights will turn red and then flash white when a note is successfully picked up. When the bot is currently holding a note, the lights will stay a solid green colour until it leaves the indexer. In the last 20 seconds of the match, the lights starting from the outside will begin to slowly dim towards the middle until there are no lights left on, at which point there will be 0 seconds left in the match. When the match ends, the bot will flash its alliance colour quickly before returning to the idle Knight rider effect.